### PR TITLE
Test multiple tomcat instances backed by single redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-build/
+.gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM java:8
+RUN mkdir /app
+ADD build/libs/springboot-redis-session-demo-0.0.1-SNAPSHOT.jar /app/
+ADD bootInDocker.sh /app/
+WORKDIR /app
+RUN chmod a+x bootInDocker.sh
+
+EXPOSE 8080
+
+CMD /app/bootInDocker.sh

--- a/bootInDocker.sh
+++ b/bootInDocker.sh
@@ -1,0 +1,1 @@
+java -jar /app/springboot-redis-session-demo-0.0.1-SNAPSHOT.jar --redis.session-store.host=redis --redis.session-store.port=6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+app1:
+  build: .
+  hostname: app1
+  links:
+    - redis
+  ports:
+    - "8081:8080"
+
+app2:
+  build: .
+  hostname: app2
+  links:
+    - redis
+  ports:
+    - "8082:8080"
+
+redis:
+  image: redis
+  hostname: redis
+  ports:
+    - "6379:6379"

--- a/src/main/java/hello/Foo.java
+++ b/src/main/java/hello/Foo.java
@@ -1,0 +1,16 @@
+package hello;
+
+import java.io.Serializable;
+
+public class Foo implements Serializable{
+
+    private String var;
+
+    public String getVar() {
+        return var;
+    }
+
+    public void setVar(String var) {
+        this.var = var;
+    }
+}

--- a/src/main/java/hello/SampleController.java
+++ b/src/main/java/hello/SampleController.java
@@ -1,12 +1,11 @@
 package hello;
 
-import org.springframework.boot.*;
-import org.springframework.boot.autoconfigure.*;
-import org.springframework.stereotype.*;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 @Controller
@@ -23,12 +22,24 @@ import javax.servlet.http.HttpSession;
     @ResponseBody
     String set(@RequestParam(name="value") String value, HttpSession session) {
         session.setAttribute("test", value);
+        Foo foo = new Foo();
+        foo.setVar(value);
+        session.setAttribute("foo", foo);
+
+        System.out.println("session.getAttribute(\"test\") ==> "+session.getAttribute("test"));
+        System.out.println("session.getAttribute(\"foo\")).getVar() ==>" +((Foo)session.getAttribute("foo")).getVar());
+
+
         return ("Set key: test to value: "+session.getAttribute("test"));
     }
 
     @RequestMapping("/get")
     @ResponseBody
     String get(HttpSession session) {
+
+        System.out.println("session.getAttribute(\"test\") ==> "+session.getAttribute("test"));
+        System.out.println("session.getAttribute(\"foo\")).getVar() ==>" +((Foo)session.getAttribute("foo")).getVar());
+
         return (String)session.getAttribute("test");
     }
 }


### PR DESCRIPTION
## Observation
* HttpSession survives the tomcat restarts
* Session is not always synced between tomcat instances

## Steps to reproduce
```
git checkout add-docker-compose
gradle clean build
docker-compose up
```
Open 4 bowser windows with these URL's-
* http://localhost:8081/set?value=test1
* http://localhost:8082/set?value=test2
* http://localhost:8081/get
* http://localhost:8082/get

<img width="1439" alt="screen shot 2017-11-15 at 12 20 30 am" src="https://user-images.githubusercontent.com/9570815/32826095-f3dad896-c99b-11e7-809e-a62a6940eb80.png">


We can see that session is not synced between the tomcat instances.

Now run `docker restart springbootredissessiondemo_app1_1` and we can check that `get` controller requests still return the same values.

## Conclusion 
Looks like pivotalsoftware/session-managers is suitable for use cases where preserving the session between server restart is the requirement. However, it doesn't seem to be suitable where creating a tomcat cluster without  the sticky-session is the requirement.


